### PR TITLE
Extra format support for ISO currency codes

### DIFF
--- a/src/main/java/com/github/fge/jsonschema/format/extra/CurrencyFormatAttribute.java
+++ b/src/main/java/com/github/fge/jsonschema/format/extra/CurrencyFormatAttribute.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2014, Francis Galiegue (fgaliegue@gmail.com)
+ *
+ * This software is dual-licensed under:
+ *
+ * - the Lesser General Public License (LGPL) version 3.0 or, at your option, any
+ *   later version;
+ * - the Apache Software License (ASL) version 2.0.
+ *
+ * The text of this file and of both licenses is available at the root of this
+ * project or, if you have the jar distribution, in directory META-INF/, under
+ * the names LGPL-3.0.txt and ASL-2.0.txt respectively.
+ *
+ * Direct link to the sources:
+ *
+ * - LGPL 3.0: https://www.gnu.org/licenses/lgpl-3.0.txt
+ * - ASL 2.0: http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+
+package com.github.fge.jsonschema.format.extra;
+
+import com.github.fge.jackson.NodeType;
+import com.github.fge.jsonschema.core.exceptions.ProcessingException;
+import com.github.fge.jsonschema.core.report.ProcessingReport;
+import com.github.fge.jsonschema.format.AbstractFormatAttribute;
+import com.github.fge.jsonschema.format.FormatAttribute;
+import com.github.fge.jsonschema.processors.data.FullData;
+import com.github.fge.msgsimple.bundle.MessageBundle;
+
+import java.util.Currency;
+import java.util.UUID;
+
+/**
+ * Format specifier for a proposed {@code uuid} attribute
+ *
+ * @see UUID#fromString(String)
+ */
+public final class CurrencyFormatAttribute
+    extends AbstractFormatAttribute
+{
+    private static final FormatAttribute instance = new CurrencyFormatAttribute();
+
+    private CurrencyFormatAttribute()
+    {
+        super("currency", NodeType.STRING);
+    }
+
+    public static FormatAttribute getInstance()
+    {
+        return instance;
+    }
+
+    @Override
+    public void validate(final ProcessingReport report,
+        final MessageBundle bundle, final FullData data)
+        throws ProcessingException
+    {
+        final String input = data.getInstance().getNode().textValue();
+
+        try {
+            Currency.getInstance(input);
+        } catch (IllegalArgumentException ignored) {
+            report.error(newMsg(data, bundle, "err.format.currency.invalid")
+                .putArgument("value", input));
+        }
+    }
+}

--- a/src/main/java/com/github/fge/jsonschema/library/format/ExtraFormatsDictionary.java
+++ b/src/main/java/com/github/fge/jsonschema/library/format/ExtraFormatsDictionary.java
@@ -23,6 +23,7 @@ import com.github.fge.jsonschema.core.util.Dictionary;
 import com.github.fge.jsonschema.core.util.DictionaryBuilder;
 import com.github.fge.jsonschema.format.FormatAttribute;
 import com.github.fge.jsonschema.format.extra.Base64FormatAttribute;
+import com.github.fge.jsonschema.format.extra.CurrencyFormatAttribute;
 import com.github.fge.jsonschema.format.extra.JsonPointerFormatAttribute;
 import com.github.fge.jsonschema.format.extra.MD5FormatAttribute;
 import com.github.fge.jsonschema.format.extra.MacAddressFormatAttribute;
@@ -76,6 +77,10 @@ public final class ExtraFormatsDictionary
 
         name = "uuid";
         attribute = UUIDFormatAttribute.getInstance();
+        builder.addEntry(name, attribute);
+
+        name = "currency";
+        attribute = CurrencyFormatAttribute.getInstance();
         builder.addEntry(name, attribute);
 
         DICTIONARY = builder.freeze();

--- a/src/main/resources/com/github/fge/jsonschema/validator/validation.properties
+++ b/src/main/resources/com/github/fge/jsonschema/validator/validation.properties
@@ -74,6 +74,7 @@ err.format.jsonpointer.invalid = input string "%s" is not a valid JSON Pointer
 err.format.macAddr.invalid = input string "%s" is not a valid MAC address
 err.format.uriTemplate.invalid = input string "%s" is not a valid URI template
 err.format.UUID.invalid = input string "%s" is not a valid UUID
+err.format.currency.invalid = input string "%s" is not a supported ISO 4217 currency code
 
 #
 # Other messages

--- a/src/test/java/com/github/fge/jsonschema/format/extra/CurrencyFormatAttributeTest.java
+++ b/src/test/java/com/github/fge/jsonschema/format/extra/CurrencyFormatAttributeTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2014, Francis Galiegue (fgaliegue@gmail.com)
+ *
+ * This software is dual-licensed under:
+ *
+ * - the Lesser General Public License (LGPL) version 3.0 or, at your option, any
+ *   later version;
+ * - the Apache Software License (ASL) version 2.0.
+ *
+ * The text of this file and of both licenses is available at the root of this
+ * project or, if you have the jar distribution, in directory META-INF/, under
+ * the names LGPL-3.0.txt and ASL-2.0.txt respectively.
+ *
+ * Direct link to the sources:
+ *
+ * - LGPL 3.0: https://www.gnu.org/licenses/lgpl-3.0.txt
+ * - ASL 2.0: http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+
+package com.github.fge.jsonschema.format.extra;
+
+import java.io.IOException;
+
+public final class CurrencyFormatAttributeTest
+    extends ExtraFormatAttributeTest
+{
+    public CurrencyFormatAttributeTest()
+        throws IOException
+    {
+        super("currency");
+    }
+}

--- a/src/test/resources/format/extra/currency.json
+++ b/src/test/resources/format/extra/currency.json
@@ -1,0 +1,19 @@
+[
+    {
+        "data": "USD",
+        "valid": true
+    },
+    {
+        "data": "CAD",
+        "valid": true
+    },
+    {
+        "data": "ATF",
+        "valid": false,
+        "message": "err.format.currency.invalid",
+        "msgData": {
+            "value": "ATF"
+        },
+        "msgParams": [ "value" ]
+    }
+]


### PR DESCRIPTION
A new format implementation to verify ISO currency codes which are much too large to support via enum